### PR TITLE
Smarter sentence segmentation for search index

### DIFF
--- a/example/templates/UsesScope.jsx
+++ b/example/templates/UsesScope.jsx
@@ -1,9 +1,9 @@
 const UsesScope = ({ page, site }) => (
     <ul>
-        <li>page.frontmatter.title: {page.frontmatter.title}</li>
-        <li>page.url: {page.url}</li>
-        <li>site.title: {site.title}</li>
-        <li>site.url: {site.url}</li>
+        <li><code>page.frontmatter.title</code>: {page.frontmatter.title}</li>
+        <li><code>page.url</code>: {page.url}</li>
+        <li><code>site.title</code>: {site.title}</li>
+        <li><code>site.url</code>: {site.url}</li>
     </ul>
 );
 

--- a/jsssg/src/search.js
+++ b/jsssg/src/search.js
@@ -7,17 +7,20 @@ import { args } from "./index.js";
 import { saveFile } from "./io.js";
 import { chunk } from "./utils.js";
 
-const parseSearchContent = markdown =>
-    markdown
-        // Remove tags
-        .replace(/<\/?[^>]+(>|$)/g, "")
-        // Split into sentences
-        .split("\n")
-        // Remove empty lines
-        .filter(line => line !== "")
+const parseSearchContent = markdown => {
+    // Remove tags
+    const content = markdown.replace(/<\/?[^>]+(>|$)/g, "");
+
+    // Split into sentences
+    const segmenter = new Intl.Segmenter("en", { granularity: "sentence" });
+    const segments = [...segmenter.segment(content)]
+        .map(segment => segment.segment)
         // Cap sentences at 240 chars
         .map(line => chunk(line, 240))
         .flat();
+
+    return segments;
+};
 
 export const buildSearchData = ({ fields, site, outPath, templates }) => {
     const allPages = site.allPages;


### PR DESCRIPTION
Using `Intl.Segmenter` instead of naive `.split("\n")`