### PR TITLE
Bugfix and version bump

### DIFF
--- a/jsssg/package.json
+++ b/jsssg/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsssg",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "description": "An opinionated static site generator built with JavaScript",
     "main": "./build/index.js",
     "devDependencies": {},

--- a/jsssg/src/build.js
+++ b/jsssg/src/build.js
@@ -16,8 +16,11 @@ export const build = async ({ PATHS, config, args }) => {
     if (args.verbose) console.log(`found ${allFiles.length} files`);
 
     if (args.verbose) console.log("Parsing frontmatter...");
-    const fileData = await Promise.all(
+    const unfilteredFileData = await Promise.all(
         allFiles.map(async filePath => await processFile(filePath, PATHS))
+    );
+    const fileData = unfilteredFileData.filter(
+        file => file.type !== "not a file"
     );
 
     if (args.verbose) console.log("Loading templates...");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3141,7 +3141,7 @@ dir-glob@^3.0.1:
   version "1.0.0"
   resolved "file:docs"
   dependencies:
-    jsssg "0.1.13"
+    jsssg "0.1.14"
     moment "^2.29.4"
     netlify-cli "^12.2.10"
 
@@ -3490,7 +3490,7 @@ eventemitter3@^4.0.0:
   version "1.0.0"
   resolved "file:example"
   dependencies:
-    jsssg "0.1.13"
+    jsssg "0.1.14"
     moment "^2.29.4"
 
 execa@^5.0.0:
@@ -5389,10 +5389,10 @@ jsonwebtoken@^8.5.1:
     ms "^2.1.1"
     semver "^5.6.0"
 
-jsssg@0.1.13:
-  version "0.1.13"
-  resolved "https://registry.npmjs.org/jsssg/-/jsssg-0.1.13.tgz"
-  integrity sha512-7LkRKYlg5uIz3P8MWfucOd4gy+ShdTpTsBvrFseEIKXRlvuGzDkRXlLKfCoDO7G65N48yOwm3eFhxpyd/y6zsQ==
+jsssg@0.1.14:
+  version "0.1.14"
+  resolved "https://registry.npmjs.org/jsssg/-/jsssg-0.1.14.tgz"
+  integrity sha512-gqQl5RdkqGdsbGXF3uswUN7WGx29Bp3iTMbdIn2JbDSVRs6rX6jE8xd8eHkp7Qq1YviHUtCWR+vEek/31Xug3w==
   dependencies:
     "@mdx-js/runtime" "^1.6.22"
     autoprefixer "^10.4.13"
@@ -5420,7 +5420,7 @@ jsssg@0.1.13:
     yaml "^2.1.3"
 
 "jsssg@file:/Users/tomhazledine/Documents/projects/jsssg/jsssg":
-  version "0.1.14"
+  version "0.1.15"
   resolved "file:jsssg"
   dependencies:
     "@mdx-js/runtime" "^1.6.22"


### PR DESCRIPTION
Non-page files (such as `.DS_Store`) were breaking frontmatter parsing. This changes filters out these pages from `fileData` at the parsing stage.