### PR TITLE
Fix typo in templates.mdx

### DIFF
--- a/docs/content/getting-started/templates.mdx
+++ b/docs/content/getting-started/templates.mdx
@@ -50,7 +50,7 @@ To apply a custom template to one of your Markdown pages, create a file called `
 
 ### Write a template
 
-In the new `Post.js` file, write your template function and export it as the default export.
+In the new `Post.jsx` file, write your template function and export it as the default export.
 
 All templates are initialised with three paramaters:
 


### PR DESCRIPTION
Corrected a minor typo in docs page file `templates.mdx`
